### PR TITLE
Use environment instead of isLocal

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -36,7 +36,7 @@ class ScheduleWorkCommand extends Command
     {
         $this->components->info(
             'Running scheduled tasks every minute.',
-            $this->getLaravel()->isLocal() ? OutputInterface::VERBOSITY_NORMAL : OutputInterface::VERBOSITY_VERBOSE
+            $this->getLaravel()->environment('local') ? OutputInterface::VERBOSITY_NORMAL : OutputInterface::VERBOSITY_VERBOSE
         );
 
         [$lastExecutionStartedAt, $executions] = [Carbon::now()->subMinutes(10), []];


### PR DESCRIPTION
The `isLocal` method is not an interface defined in the Application contract.

Therefore, the `environment` method, which provides similar functionality, is used instead.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
